### PR TITLE
DisplayCutout is not available on api < 28

### DIFF
--- a/src/android/AndroidNotch.java
+++ b/src/android/AndroidNotch.java
@@ -46,9 +46,9 @@ public class AndroidNotch extends CordovaPlugin {
             return true;
         }
 
-        if(Build.VERSION.SDK_INT < 23) {
+        if(Build.VERSION.SDK_INT < 28) {
 
-            // Insets are not available on api < 23
+            // DisplayCutout is not available on api < 28
             callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, 0));
             return true;
         }


### PR DESCRIPTION
On Androids with API level < 28 an error occurs because the method insets.getDisplayCutout() is not found.

I'd be happy if you could merge the pull request.